### PR TITLE
ensure there is a valid file for publish from maya

### DIFF
--- a/maya-tools/shelf/scripts/publish.py
+++ b/maya-tools/shelf/scripts/publish.py
@@ -1,4 +1,6 @@
 from byuam import Department
+from byuam import Environment
+from byuam import pipeline_io
 from byugui.publish_gui import PublishWindow
 from PySide2 import QtWidgets
 import maya.cmds as cmds
@@ -47,6 +49,12 @@ def post_publish():
 def go():
     parent = maya_main_window()
     filePath = cmds.file(q=True, sceneName=True)
+    if not filePath:
+        filePath = Environment().get_user_workspace()
+        filePath = os.path.join(filePath, 'untitled.mb')
+        filePath = pipeline_io.version_file(filePath)
+        cmds.file(rename=filePath)
+        cmds.file(save=True)
     global maya_publish_dialog
     maya_publish_dialog = PublishWindow(filePath, parent, [Department.MODEL, Department.RIG, Department.LAYOUT, Department.ANIM, Department.CFX])
     maya_publish_dialog.finished.connect(post_publish)


### PR DESCRIPTION
I was reading  byu-animation.github.io (which is awesome, by the way) and I came across the "Your First Publish" which mentions that if someone tries to publish a file from maya that hasn't been saved, it will crash and they'll lose all their work. This made me sad. I think this will fix it.